### PR TITLE
Update version tag pattern in version.json

### DIFF
--- a/version.json
+++ b/version.json
@@ -3,7 +3,7 @@
   "version": "0.2-rc",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
-    "^refs/heads/v\\d+(?:\\.\\d+)?$"
+    "^refs/tags/v\\d+(?:\\.\\d+){0,2}(?:-.+)?$"
   ],
   "cloudBuild": {
     "setVersionVariables": false


### PR DESCRIPTION
Replaced the `publicReleaseRefSpec` pattern in `version.json` to allow for more complex versioning schemes. The new pattern `^refs/tags/v\\d+(?:\\.\\d+){0,2}(?:-.+)?$` supports tags with multiple numeric components and optional suffixes, broadening the scope of version tags considered for public release.