### PR TITLE
Add XML documentation support and improve assembly resolver test cove…

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Using `SharpAssemblyResolver.Builder.AddReferenceDirectories("path/to/target-fra
 - Log errors and information during the loading process.
 - Utilize `MetadataLoadContext` for inspecting assemblies without loading them into the main application domain.
 - Extension methods for `Type`, `PropertyInfo`, `MemberInfo`, and `CustomAttributeData` to facilitate inspecting type and attribute metadata.
+- Get XML documentation comments for types, properties, and members (requires XML documentation files to be present).
 
 ## Getting Started
 

--- a/src/sharp-meta/DocComments.cs
+++ b/src/sharp-meta/DocComments.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Immutable;
+using System.Diagnostics;
+
+namespace SharpMeta;
+
+/// <summary>
+/// Represents the documentation comments for a member.
+/// </summary>
+[DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
+public record DocComments(
+    string? Summary,
+    ImmutableArray<(string Name, string Value)> Parameters,
+    string? Returns)
+{
+    private string GetDebuggerDisplay()
+    {
+        return $"({this.Summary}) [{this.Parameters.Length}] {{{this.Returns}}}";
+    }
+}

--- a/test/sharp-meta.Tests/MemberInfoExtensionsTests.cs
+++ b/test/sharp-meta.Tests/MemberInfoExtensionsTests.cs
@@ -35,6 +35,15 @@ public class MemberInfoExtensionsTests
     }
 
     [Fact]
+    public void TryGetCustomAttributeData_FromMemberInfoAndFullName_ShouldReturnTrue()
+    {
+        MethodInfo? member = typeof(SampleClass).GetMethod(nameof(SampleClass.SampleMethod));
+        bool result = member!.TryGetCustomAttributeData("SharpMeta.Tests.SampleAttribute", out CustomAttributeData? attributeData);
+        Assert.True(result);
+        Assert.NotNull(attributeData);
+    }
+
+    [Fact]
     public void GetAllCustomAttributeData_ShouldReturnAllAttributes()
     {
         Type type = typeof(SampleClass);
@@ -68,5 +77,83 @@ public class MemberInfoExtensionsTests
         IList<CustomAttributeData>? attributes = member!.GetAllCustomAttributeData(includeInherited: true);
         Assert.NotNull(attributes);
         Assert.Contains(attributes, a => a.AttributeType == typeof(SampleAttribute));
+    }
+
+    [Fact]
+    public void GetAllCustomAttributeData_ShouldReturnAttributesForProperty()
+    {
+        PropertyInfo? property = typeof(SampleClass).GetProperty(nameof(SampleClass.AttributedProperty));
+        IList<CustomAttributeData>? attributes = property!.GetAllCustomAttributeData(includeInherited: false);
+        Assert.NotNull(attributes);
+        Assert.Contains(attributes, a => a.AttributeType == typeof(SampleAttribute));
+    }
+
+    [Fact]
+    public void GetAllCustomAttributeData_ShouldIncludeInheritedAttributesForProperty()
+    {
+        PropertyInfo? property = typeof(DerivedSampleClass).GetProperty(nameof(DerivedSampleClass.AttributedProperty));
+        IList<CustomAttributeData>? attributes = property!.GetAllCustomAttributeData(includeInherited: true);
+        Assert.NotNull(attributes);
+        Assert.Contains(attributes, a => a.AttributeType == typeof(SampleAttribute));
+    }
+
+    [Fact]
+    public void TryGetDocComments_ShouldReturnFalse_WhenMemberInfoIsNull()
+    {
+        MemberInfo? memberInfo = null;
+        bool result = memberInfo!.TryGetDocComments(out DocComments? docComments);
+        Assert.False(result);
+        Assert.Null(docComments);
+    }
+
+    [Fact]
+    public void TryGetDocComments_ShouldReturnFalse_WhenMemberNotFoundInXmlDocumentation()
+    {
+        Type type = typeof(SampleClassWithoutDocs);
+        bool result = type.TryGetDocComments(out DocComments? docComments);
+        Assert.False(result);
+        Assert.Null(docComments);
+    }
+
+    [Fact]
+    public void TryGetDocComments_ShouldReturnTrue_WhenMemberFoundInXmlDocumentation()
+    {
+        Type type = typeof(SampleClass);
+        bool result = type.TryGetDocComments(out DocComments? docComments);
+        Assert.True(result);
+        Assert.NotNull(docComments);
+        Assert.Equal("A sample class.", docComments?.Summary);
+    }
+
+    [Fact]
+    public void TryGetDocComments_ShouldReturnTrue_ForMethod()
+    {
+        MethodInfo? method = typeof(SampleClass).GetMethod(nameof(SampleClass.SampleMethod));
+        bool result = method!.TryGetDocComments(out DocComments? docComments);
+        Assert.True(result);
+        Assert.NotNull(docComments);
+        Assert.Equal("A sample method.", docComments?.Summary);
+    }
+
+    [Fact]
+    public void TryGetDocComments_ShouldReturnTrue_ForProperty()
+    {
+        PropertyInfo? property = typeof(SampleClass).GetProperty(nameof(SampleClass.NullableProperty));
+        bool result = property!.TryGetDocComments(out DocComments? docComments);
+        Assert.True(result);
+        Assert.NotNull(docComments);
+        Assert.Equal("Gets or sets a nullable property.", docComments?.Summary);
+        Assert.Empty(docComments!.Parameters);
+    }
+
+    [Fact]
+    public void TryGetDocComments_ShouldReturnTrue_ForObsoleteMethod()
+    {
+        MethodInfo? method = typeof(SampleClass).GetMethod(nameof(SampleClass.ObsoleteMethod));
+        bool result = method!.TryGetDocComments(out DocComments? docComments);
+        Assert.True(result);
+        Assert.NotNull(docComments);
+        Assert.Equal("An obsolete method.", docComments?.Summary);
+        Assert.Empty(docComments!.Parameters);
     }
 }

--- a/test/sharp-meta.Tests/SampleClass.cs
+++ b/test/sharp-meta.Tests/SampleClass.cs
@@ -1,14 +1,30 @@
-﻿
-namespace SharpMeta.Tests;
+﻿namespace SharpMeta.Tests;
 
+/// <summary>
+/// A sample class.
+/// </summary>
 [Sample(42, Name = "Test")]
 public class SampleClass
 {
+    /// <summary>
+    /// Gets or sets a nullable property.
+    /// </summary>
     public int? NullableProperty { get; set; }
 
     [Sample(42)]
+    public bool AttributedProperty { get; set; }
+
+    /// <summary>
+    /// A sample method.
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="NotImplementedException"></exception>
+    [Sample(42)]
     public object SampleMethod() => throw new NotImplementedException();
 
+    /// <summary>
+    /// An obsolete method.
+    /// </summary>
     [Obsolete("This method is obsolete")]
     public void ObsoleteMethod() { }
 }

--- a/test/sharp-meta.Tests/SampleClassWithoutDocs.cs
+++ b/test/sharp-meta.Tests/SampleClassWithoutDocs.cs
@@ -1,0 +1,11 @@
+namespace SharpMeta.Tests;
+
+public class SampleClassWithoutDocs
+{
+    public int? NullableProperty { get; set; }
+
+    public object SampleMethod() => throw new NotImplementedException();
+
+    [Obsolete("This method is obsolete")]
+    public void ObsoleteMethod() { }
+}

--- a/test/sharp-meta.Tests/SharpAssemblyResolverBuilderTests.cs
+++ b/test/sharp-meta.Tests/SharpAssemblyResolverBuilderTests.cs
@@ -28,6 +28,13 @@ public class SharpAssemblyResolverBuilderTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void AddReferenceDirectory_ShouldThrowArgumentNullException_WhenDirectoryIsNull()
+    {
+        SharpAssemblyResolver.Builder builder = SharpAssemblyResolver.CreateBuilder(_logger);
+        Assert.Throws<ArgumentNullException>(() => builder.AddReferenceDirectory(null!));
+    }
+
+    [Fact]
     public void AddReferenceDirectories_ShouldAddAssembliesFromMultipleDirectories()
     {
         SharpAssemblyResolver.Builder builder = SharpAssemblyResolver.CreateBuilder(_logger);
@@ -42,6 +49,13 @@ public class SharpAssemblyResolverBuilderTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public void AddReferenceDirectories_ShouldThrowArgumentNullException_WhenDirectoriesAreNull()
+    {
+        SharpAssemblyResolver.Builder builder = SharpAssemblyResolver.CreateBuilder(_logger);
+        Assert.Throws<ArgumentNullException>(() => builder.AddReferenceDirectories(new EnumerationOptions(), null!));
+    }
+
+    [Fact]
     public void AddReferenceFile_ShouldAddAssemblyFromFile()
     {
         SharpAssemblyResolver.Builder builder = SharpAssemblyResolver.CreateBuilder(_logger);
@@ -49,6 +63,13 @@ public class SharpAssemblyResolverBuilderTests(ITestOutputHelper outputHelper)
         builder.AddReferenceFile(file);
         SharpAssemblyResolver resolver = builder.ToAssemblyResolver();
         Assert.NotNull(resolver);
+    }
+
+    [Fact]
+    public void AddReferenceFile_ShouldThrowArgumentNullException_WhenFileIsNull()
+    {
+        SharpAssemblyResolver.Builder builder = SharpAssemblyResolver.CreateBuilder(_logger);
+        Assert.Throws<ArgumentNullException>(() => builder.AddReferenceFile(null!));
     }
 
     [Fact]
@@ -63,6 +84,13 @@ public class SharpAssemblyResolverBuilderTests(ITestOutputHelper outputHelper)
         builder.AddReferenceFiles(files);
         SharpAssemblyResolver resolver = builder.ToAssemblyResolver();
         Assert.NotNull(resolver);
+    }
+
+    [Fact]
+    public void AddReferenceFiles_ShouldThrowArgumentNullException_WhenFilesAreNull()
+    {
+        SharpAssemblyResolver.Builder builder = SharpAssemblyResolver.CreateBuilder(_logger);
+        Assert.Throws<ArgumentNullException>(() => builder.AddReferenceFiles(null!));
     }
 
     [Fact]
@@ -81,6 +109,26 @@ public class SharpAssemblyResolverBuilderTests(ITestOutputHelper outputHelper)
         builder.AddRuntimeEnvironmentAssemblies();
         SharpAssemblyResolver resolver = builder.ToAssemblyResolver();
         Assert.NotNull(resolver);
+    }
+
+    [Fact]
+    public void AddAssembliesFromDirectory_ShouldLogWarning_WhenDirectoryDoesNotExist()
+    {
+        var logger = new TestLogger();
+        SharpAssemblyResolver.Builder builder = SharpAssemblyResolver.CreateBuilder(logger);
+        var directory = new DirectoryInfo("NonExistentDirectory");
+        builder.AddReferenceDirectory(directory);
+        Assert.Contains($"Directory not found: {directory.FullName}.", logger.Warnings);
+    }
+
+    [Fact]
+    public void AddAssembly_ShouldLogWarning_WhenFileDoesNotExist()
+    {
+        var logger = new TestLogger();
+        SharpAssemblyResolver.Builder builder = SharpAssemblyResolver.CreateBuilder(logger);
+        var file = new FileInfo("NonExistentFile.dll");
+        builder.AddReferenceFile(file);
+        Assert.Contains($"File not found: {file.FullName}.", logger.Warnings);
     }
 
     [Fact]
@@ -120,13 +168,49 @@ public class SharpAssemblyResolverBuilderTests(ITestOutputHelper outputHelper)
         Assert.DoesNotContain($"Overwriting existing assembly path: {file2.FullName}.", logger.Warnings);
     }
 
+    [Fact]
+    public void AddReferenceFile_ShouldIncludeSideBySideAssemblies()
+    {
+        // Arrange
+        var logger = new TestLogger();
+        SharpAssemblyResolver.Builder builder = SharpAssemblyResolver.CreateBuilder(logger);
+        var file = new FileInfo(Assembly.GetExecutingAssembly().Location);
+
+        // Act
+        builder.AddReferenceFile(file, includeSideBySideAssemblies: true);
+        SharpAssemblyResolver resolver = builder.ToAssemblyResolver();
+
+        // Assert
+        Assert.NotNull(resolver);
+        Assert.Contains("Added assembly:", string.Join(' ',logger.Infos));
+    }
+
+    [Fact]
+    public void AddReferenceFile_ShouldLogError_WhenFileDirectoryNotFound()
+    {
+        // Arrange
+        var logger = new TestLogger();
+        SharpAssemblyResolver.Builder builder = SharpAssemblyResolver.CreateBuilder(logger);
+        var file = new FileInfo("NonExistentFile.dll");
+
+        // Act
+        builder.AddReferenceFile(file, includeSideBySideAssemblies: false);
+
+        // Assert
+        Assert.Contains("File not found:", string.Join(' ', logger.Warnings));
+    }
+
     private class TestLogger : SharpResolverLogger
     {
+        public List<string> Infos { get; } = new List<string>();
         public List<string> Warnings { get; } = new List<string>();
+        public List<string> Errors { get; } = new List<string>();
 
         public TestLogger()
         {
+            this.OnInfo = message => this.Infos.Add(message);
             this.OnWarning = message => this.Warnings.Add(message);
+            this.OnError = message => this.Errors.Add(message);
         }
     }
 }


### PR DESCRIPTION
…rage

This commit introduces functionality for handling XML documentation comments in the `SharpMeta` namespace, including a new `DocComments` record and an extension method `TryGetDocComments` in `MemberInfoExtensions`. The method caches loaded XML documents for better performance.