### PR TITLE
Refactor PropertyInfoExtensions for thread-local context

### DIFF
--- a/src/sharp-meta/PropertyInfoExtensions.cs
+++ b/src/sharp-meta/PropertyInfoExtensions.cs
@@ -7,7 +7,7 @@ namespace SharpMeta;
 /// </summary>
 public static class PropertyInfoExtensions
 {
-    private static readonly NullabilityInfoContext NullabilityContext = new();
+    private static readonly ThreadLocal<NullabilityInfoContext> ThreadLocalNullabilityContext = new(() => new NullabilityInfoContext());
 
     /// <summary>
     /// Determines whether the specified property is nullable.
@@ -41,7 +41,10 @@ public static class PropertyInfoExtensions
     {
         ArgumentNullException.ThrowIfNull(property);
 
-        NullabilityInfo nullabilityInfo = NullabilityContext.Create(property);
-        return nullabilityInfo.ReadState == NullabilityState.Nullable;
+        NullabilityInfo? nullabilityInfo = ThreadLocalNullabilityContext.Value?.Create(property);
+
+        return nullabilityInfo is null
+            ? throw new InvalidOperationException("Failed to retrieve nullability information.")
+            : nullabilityInfo.ReadState == NullabilityState.Nullable;
     }
 }

--- a/src/sharp-meta/PropertyInfoExtensions.cs
+++ b/src/sharp-meta/PropertyInfoExtensions.cs
@@ -7,7 +7,7 @@ namespace SharpMeta;
 /// </summary>
 public static class PropertyInfoExtensions
 {
-    private static readonly ThreadLocal<NullabilityInfoContext> ThreadLocalNullabilityContext = new(() => new NullabilityInfoContext());
+    private static readonly ThreadLocal<NullabilityInfoContext> NullabilityContext = new(() => new NullabilityInfoContext());
 
     /// <summary>
     /// Determines whether the specified property is nullable.
@@ -41,10 +41,9 @@ public static class PropertyInfoExtensions
     {
         ArgumentNullException.ThrowIfNull(property);
 
-        NullabilityInfo? nullabilityInfo = ThreadLocalNullabilityContext.Value?.Create(property);
+        NullabilityInfo nullabilityInfo = NullabilityContext.Value?.Create(property)
+            ?? throw new InvalidOperationException($"Failed creating nullability context for property {property.Name}.");
 
-        return nullabilityInfo is null
-            ? throw new InvalidOperationException("Failed to retrieve nullability information.")
-            : nullabilityInfo.ReadState == NullabilityState.Nullable;
+        return nullabilityInfo.ReadState == NullabilityState.Nullable;
     }
 }

--- a/test/sharp-meta.Tests/PropertyInfoExtensionsTests.cs
+++ b/test/sharp-meta.Tests/PropertyInfoExtensionsTests.cs
@@ -12,6 +12,33 @@ public class PropertyInfoExtensionsTests
         public string? NullableReferenceType { get; set; }
     }
 
+    public class PropertyInfoExtensionsThreadSafetyTests
+    {
+        private class TestClass
+        {
+            public string? NullableReferenceType { get; set; }
+        }
+
+        [Fact]
+        public async Task IsNullableReference_ShouldBeThreadSafe()
+        {
+            System.Reflection.PropertyInfo? property = typeof(TestClass).GetProperty(nameof(TestClass.NullableReferenceType));
+            var tasks = new List<Task<bool>>();
+
+            for (int i = 0; i < 100; i++)
+            {
+                tasks.Add(Task.Run(() => property!.IsNullableReference()));
+            }
+
+            await Task.WhenAll(tasks);
+
+            foreach (Task<bool> task in tasks)
+            {
+                Assert.True(await task);
+            }
+        }
+    }
+
     [Fact]
     public void IsNullable_ShouldReturnTrue_ForNullableValueType()
     {


### PR DESCRIPTION
Replaced the static `NullabilityContext` with a
`ThreadLocal<NullabilityInfoContext>` to improve
safety in multi-threaded scenarios.