### PR TITLE
Add IsRequiredMember method to PropertyInfoExtensions

### DIFF
--- a/src/sharp-meta/PropertyInfoExtensions.cs
+++ b/src/sharp-meta/PropertyInfoExtensions.cs
@@ -46,4 +46,21 @@ public static class PropertyInfoExtensions
 
         return nullabilityInfo.ReadState == NullabilityState.Nullable;
     }
+
+    /// <summary>
+    /// Determines whether the specified property is marked with the <see cref="System.Runtime.CompilerServices.RequiredMemberAttribute"/>.
+    /// </summary>
+    /// <param name="property">The property to check.</param>
+    /// <returns><see langword="true"/> if the property is marked with the <see cref="System.Runtime.CompilerServices.RequiredMemberAttribute"/>; otherwise, <see langword="false"/>.</returns>
+    public static bool IsRequiredMember(this PropertyInfo property)
+    {
+        ArgumentNullException.ThrowIfNull(property);
+
+        if (property.TryGetCustomAttributeData<System.Runtime.CompilerServices.RequiredMemberAttribute>(out _))
+        {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/src/sharp-meta/PropertyInfoExtensions.cs
+++ b/src/sharp-meta/PropertyInfoExtensions.cs
@@ -49,6 +49,7 @@ public static class PropertyInfoExtensions
 
     /// <summary>
     /// Determines whether the specified property is marked with the <see cref="System.Runtime.CompilerServices.RequiredMemberAttribute"/>.
+    /// Such as for properties marked <see langword="required"/>.
     /// </summary>
     /// <param name="property">The property to check.</param>
     /// <returns><see langword="true"/> if the property is marked with the <see cref="System.Runtime.CompilerServices.RequiredMemberAttribute"/>; otherwise, <see langword="false"/>.</returns>

--- a/test/sharp-meta.Tests/PropertyInfoExtensionsTests.cs
+++ b/test/sharp-meta.Tests/PropertyInfoExtensionsTests.cs
@@ -12,6 +12,12 @@ public class PropertyInfoExtensionsTests
         public string? NullableReferenceType { get; set; }
     }
 
+    private class RequiredMemberTestClass
+    {
+        public required string RequiredProperty { get; set; } = string.Empty;
+        public string NonRequiredProperty { get; set; } = string.Empty;
+    }
+
     public class PropertyInfoExtensionsThreadSafetyTests
     {
         private class TestClass
@@ -84,6 +90,22 @@ public class PropertyInfoExtensionsTests
     {
         System.Reflection.PropertyInfo? property = typeof(TestClass).GetProperty(nameof(TestClass.NonNullableReferenceType));
         bool result = property!.IsNullableReference();
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsRequiredMember_ShouldReturnTrue_ForRequiredMember()
+    {
+        System.Reflection.PropertyInfo? property = typeof(RequiredMemberTestClass).GetProperty(nameof(RequiredMemberTestClass.RequiredProperty));
+        bool result = property!.IsRequiredMember();
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsRequiredMember_ShouldReturnFalse_ForNonRequiredMember()
+    {
+        System.Reflection.PropertyInfo? property = typeof(RequiredMemberTestClass).GetProperty(nameof(RequiredMemberTestClass.NonRequiredProperty));
+        bool result = property!.IsRequiredMember();
         Assert.False(result);
     }
 }


### PR DESCRIPTION
Introduced a new method `IsRequiredMember` that checks if a property is marked with the `RequiredMemberAttribute`. Indicates a property is declared with this syntax: `public required string Prop {get; init}`.